### PR TITLE
Profile for Rotate MD-80 Pro (#44)

### DIFF
--- a/aircraftConfigs/MD88_by_(c) 2.sacfg
+++ b/aircraftConfigs/MD88_by_(c) 2.sacfg
@@ -1,0 +1,318 @@
+{
+    "enabled": true,
+    "acf": {
+        "icao": "MD88",
+        "author": "(c) 2013-2017 Juan Alcon, Ivan Arroyo, Pedro Muñoz, Alfredo Torrado"
+    },
+    "speed": {
+        "taxi": 30
+    },
+    "autoUpdate": true,
+    "replace_dref": [],
+    "checkHeights": [
+        {
+            "name": "IMC",
+            "height": 1000,
+            "primaryCondition": "$sim/weather/visibility_reported_m < 5000 or ((($sim/weather/cloud_base_msl_m[0] - $analysis.touchdown_combined.elevation) < 450) and $sim/weather/cloud_coverage[0] >= 4)",
+            "description": "Instrument approach in IMC conditions"
+        },
+        {
+            "name": "VMC",
+            "height": 500,
+            "primaryCondition": "1",
+            "description": "Instrument approach in VMC conditions"
+        },
+        {
+            "name": "VISUAL",
+            "height": 500,
+            "primaryCondition": "0",
+            "description": "Visual approach can only be selected manually\n\nPlugins -> StableApproach -> Check height"
+        }
+    ],
+    "requirementGroups": [
+        {
+            "name": "Stopping distance",
+            "requirements": [
+                {
+                    "name": "Runway overshoot",
+                    "type": 2,
+                    "primaryCondition": "$analysis.rollout.rwy_remaining > 0",
+                    "beginConditionMarker": "#TD_FIRST",
+                    "endConditionMarker": "$clamb/stableapproach/position/groundspeed_kn < 60",
+                    "description": "Taxi speed when reaching end of runway\n"
+                }
+            ]
+        },
+        {
+            "requirements": [
+                {
+                    "name": "Touchdown zone",
+                    "type": 2,
+                    "primaryCondition": "$analysis.touchdown_combined.threshold_dist.max < $analysis.rwy.length.tdz and $analysis.touchdown_combined.threshold_dist.min > 0",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#INSTANT",
+                    "description": "Touchdown(s) within touchdown zone"
+                }
+            ]
+        },
+        {
+            "requirements": [
+                {
+                    "name": "Centerline deviation",
+                    "type": 2,
+                    "primaryCondition": "abs($clamb/stableapproach/live/runway/cte) < (($analysis.rwy.width / 2) - 1)",
+                    "beginConditionMarker": "#TD_FIRST",
+                    "endConditionMarker": "$clamb/stableapproach/position/groundspeed_kn < 60",
+                    "tolerance": 1000,
+                    "description": "Stay on centerline until reaching 60kn groundspeed"
+                }
+            ]
+        },
+        {
+            "name": "Single touchdown",
+            "requirements": [
+                {
+                    "name": "Bounced landing",
+                    "type": 1,
+                    "primaryCondition": "$analysis.touchdown_combined.touchdown_count == 1",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#INSTANT",
+                    "description": "After touchdown the aircraft should not get airborne again"
+                }
+            ]
+        },
+        {
+            "name": "Touchdown rate (fpm)",
+            "requirements": [
+                {
+                    "name": "Severe hard landing (fpm)",
+                    "type": 2,
+                    "primaryCondition": "$analysis.touchdown_combined.fpm_agl.max > -900",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TAXI",
+                    "description": "Maximum sinkrate during touchdown:\n600 fpm"
+                },
+                {
+                    "name": "Hard landing (fpm)",
+                    "type": 2,
+                    "primaryCondition": "$analysis.touchdown_combined.fpm_agl.max > -600",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TAXI",
+                    "description": "Maximum sinkrate during touchdown:\n600 fpm"
+                }
+            ]
+        },
+        {
+            "name": "Touchdown g-force",
+            "requirements": [
+                {
+                    "name": "Severe hard landing (g)",
+                    "type": 2,
+                    "primaryCondition": "$analysis.touchdown_combined.g_vertical.max < 2.6",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TAXI",
+                    "description": "Max vertical acceleration after touchdown:\n2.1 G"
+                },
+                {
+                    "name": "Hard landing (g)",
+                    "type": 2,
+                    "primaryCondition": "$analysis.touchdown_combined.g_vertical.max < 2.1",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TAXI",
+                    "description": "Max vertical acceleration after touchdown:\n2.1 G"
+                }
+            ]
+        },
+        {
+            "name": "Sinkrate",
+            "requirements": [
+                {
+                    "name": "High sinkrate",
+                    "type": 2,
+                    "primaryCondition": "$sim/flightmodel/position/vh_ind_fpm > -1300",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TD_LAST",
+                    "tolerance": 3000,
+                    "description": "Max sinkrate during approach is normally:\n1000fpm"
+                },
+                {
+                    "name": "High sinkrate",
+                    "type": 1,
+                    "primaryCondition": "$sim/flightmodel/position/vh_ind_fpm > -1100",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TAXI",
+                    "tolerance": 3000,
+                    "description": "Max sinkrate during approach is normally:\n1000fpm"
+                }
+            ]
+        },
+        {
+            "name": "Approach speed",
+            "requirements": [
+                {
+                    "name": "Approach speed",
+                    "type": 2,
+                    "primaryCondition": "($Rotate/md80/autopilot/at_target_speed - 3) <= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot and ($Rotate/md80/autopilot/at_target_speed + 20) >= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "$.ft_ARTE < 100",
+                    "tolerance": 3000,
+                    "description": "Speed during approach must be between: VREF and VREF +15"
+                },
+                {
+                    "name": "Approach speed",
+                    "type": 1,
+                    "primaryCondition": "$Rotate/md80/autopilot/at_target_speed <= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot and ($Rotate/md80/autopilot/at_target_speed + 15) >= $sim/cockpit2/gauges/indicators/airspeed_kts_pilot",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "$.ft_ARTE < 100",
+                    "tolerance": 3000,
+                    "description": "Speed during approach must be between: VREF and VREF +15"
+                }
+            ]
+        },
+        {
+            "name": "Glideslope deviation",
+            "requirements": [
+                {
+                    "name": "Glideslope deviation",
+                    "type": 2,
+                    "primaryCondition": "abs($sim/cockpit/radios/nav1_vdef_dot) < 1.3",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "$.ft_ARTE < 200",
+                    "secondaryCondition": "$analysis.app.nav.gs.type == 6 and $.not_vis_app",
+                    "secondaryConditionMarker": "#TD-3000ms",
+                    "tolerance": 2000,
+                    "description": "Maximum 1 dot glideslope deviation.\nFrom check height until 200ft above runway threshold elevation (ARTE).\nNot required for VISUAL approaches"
+                },
+                {
+                    "name": "Glideslope deviation",
+                    "type": 1,
+                    "primaryCondition": "abs($sim/cockpit/radios/nav1_vdef_dot) < 1",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "$.ft_ARTE < 200",
+                    "secondaryCondition": "$analysis.app.nav.gs.type == 6 and $.not_vis_app",
+                    "secondaryConditionMarker": "#TD-3000ms",
+                    "description": "Maximum 1 dot glideslope deviation.\nFrom check height until 200ft above runway threshold elevation (ARTE).\nNot required for VISUAL approaches"
+                }
+            ]
+        },
+        {
+            "name": "Localizer deviation",
+            "requirements": [
+                {
+                    "name": "Localizer deviation",
+                    "type": 2,
+                    "primaryCondition": "abs($sim/cockpit/radios/nav1_hdef_dot) < 1.3",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TD-3000ms",
+                    "secondaryCondition": "$analysis.app.nav.loc.type != 0 and $.not_vis_app",
+                    "secondaryConditionMarker": "#TD-3000ms",
+                    "tolerance": 2000,
+                    "description": "Maximum 1 dot localizer deviation\nfrom check height till touchdown.\nNot required for VISUAL approaches"
+                },
+                {
+                    "name": "Localizer deviation",
+                    "type": 1,
+                    "primaryCondition": "abs($sim/cockpit/radios/nav1_hdef_dot) < 1",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TD-3000ms",
+                    "secondaryCondition": "$analysis.app.nav.loc.type != 0 and $.not_vis_app",
+                    "secondaryConditionMarker": "#TD-3000ms",
+                    "tolerance": 2000,
+                    "description": "Maximum 1 dot localizer deviation from check height till touchdown.\nNot required for VISUAL approaches"
+                }
+            ]
+        },
+        {
+            "name": "Gear",
+            "requirements": [
+                {
+                    "name": "Gear not down",
+                    "type": 2,
+                    "primaryCondition": "$Rotate/md80/misc/gear_handle == 1",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TAXI",
+                    "description": "Gear must be down below check height"
+                }
+            ]
+        },
+        {
+            "name": "Flaps",
+            "requirements": [
+                {
+                    "name": "Flaps not in position",
+                    "type": 2,
+                    "primaryCondition": "$Rotate/md80/systems/flap_handle_position_ratio > 0.940 or ($Rotate/md80/systems/flap_handle_position_ratio >= 0.745 and $Rotate/md80/systems/flap_handle_position_ratio <= 0.755)",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TAXI",
+                    "description": "Flaps must be in landing position (28 or 40) below check height until taxi speed"
+                }
+            ]
+        },
+        {
+            "name": "Speedbrake",
+            "requirements": [
+                {
+                    "name": "Speedbrake not armed",
+                    "type": 2,
+                    "primaryCondition": "$Rotate/md80/systems/speedbrake_position == -1",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TD-3000ms",
+                    "secondaryCondition": "$analysis.rollout.go_around == 0",
+                    "secondaryConditionMarker": "#TD-3000ms",
+                    "tolerance": 500,
+                    "description": "Speedbrakes must be in the ARMED position below check height.\nNot required in case of touch-and-go"
+                }
+            ]
+        },
+        {
+            "name": "Ignition System",
+            "requirements": [
+                {
+                    "name": "Ignition switch not in OVRD position",
+                    "type": 2,
+                    "primaryCondition": "$Rotate/md80/engines/igniter_switch == 4",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TAXI",
+                    "tolerance": 500,
+                    "description": "Ignition switch must be in position OVRD below check height"
+                }
+            ]
+        },
+        {
+            "name": "Autoflight",
+            "requirements": [
+                {
+                    "name": "Autoland",
+                    "type": 0,
+                    "primaryCondition": "$Rotate/md80/autopilot/ap_toggle == 2",
+                    "beginConditionMarker": "#TD-3000ms",
+                    "endConditionMarker": "#TD+3000ms",
+                    "description": "Information only: Autoland"
+                },
+                {
+                    "name": "Autopilot engaged",
+                    "type": 0,
+                    "primaryCondition": "$Rotate/md80/autopilot/ap_toggle == 2",
+                    "beginConditionMarker": "#CH",
+                    "endConditionMarker": "#TD-3000ms",
+                    "tolerance": 1000,
+                    "description": "Information only: Autopilot Engaged"
+                }
+            ]
+        },
+        {
+            "name": "Wind limits",
+            "requirements": [
+                {
+                    "name": "Strong tailwind",
+                    "type": 1,
+                    "primaryCondition": "$clamb/stableapproach/live/runway/hwc_kn > -10",
+                    "beginConditionMarker": "$.ft_ARTE < 50",
+                    "endConditionMarker": "#TD_LAST",
+                    "tolerance": 1000,
+                    "description": "Tailwind on runway was above 10kn.\nMake the opposite runway would be more suitable."
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
* Profile for Rotate MD-80 Pro

Full flap (40) returns 0.95 with Rotate dataref, default returns 1.

Flaps 28 returns 0.75 with Rotate dataref, default returns 0.8333

Both can be used, I decided to go with aircraft datarefs.

* Changed VMC check height to 500ft

Co-authored-by: Clamb94 <axel@reinemuth.de>